### PR TITLE
Allow dots for version numbers

### DIFF
--- a/class.discussionextender.plugin.php
+++ b/class.discussionextender.plugin.php
@@ -119,7 +119,7 @@ class DiscussionExtender extends Gdn_Plugin {
 
       // Make Options an array
       if ($Options = GetValue('Options', $FormPostValues)) {
-        $Options = explode("\n", preg_replace('`[^\w\s-]`', '', $Options));
+        $Options = explode("\n", preg_replace('`[^\w\s.-]`', '', $Options));
         if (count($Options) < 2) {
           $Sender->Form->AddError('Must have at least 2 options.', 'Options');
         }


### PR DESCRIPTION
Hi there,

currently dots gets removed and so version numbers are looking really bad. Please merge this pull request and allow dots instead of replacing/deleting them. Dots are kinda necessary for version numbers, e.g. v1.9.8.7.6. Otherwise version numbers get really unreadable (e.g. v1.9.8.7.6 becomes v19876).

Cheers!
